### PR TITLE
Add React UI and appointment API

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "doc-ai-frontend",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "serve public"
+  },
+  "devDependencies": {
+    "serve": "^14.2.0"
+  }
+}

--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -1,0 +1,13 @@
+function App() {
+  return (
+    <div>
+      <h1>Doctor Appointment Assistant</h1>
+      <h2>Chat</h2>
+      <Chat />
+      <h2>Appointments</h2>
+      <Calendar />
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/public/calendar.js
+++ b/frontend/public/calendar.js
@@ -1,0 +1,43 @@
+function Calendar() {
+  const [appointments, setAppointments] = React.useState([]);
+
+  React.useEffect(() => {
+    fetch("http://localhost:8000/appointments")
+      .then(res => res.json())
+      .then(data => setAppointments(data))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <table border="1" cellPadding="5" cellSpacing="0">
+      <thead>
+        <tr>
+          <th>Department</th>
+          <th>Doctor</th>
+          <th>Date</th>
+          <th>Time</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {appointments.map((appt, idx) => {
+          const date = new Date(appt.time_slot);
+          const statusClass = appt.status === 'scheduled'
+            ? 'busy'
+            : (appt.is_available ? 'available' : 'holiday');
+          const timeStr = date.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
+          const dateStr = date.toLocaleDateString();
+          return (
+            <tr key={idx} className={statusClass}>
+              <td>{appt.department_name}</td>
+              <td>{appt.doctor_name}</td>
+              <td>{dateStr}</td>
+              <td>{timeStr}</td>
+              <td><span className={`status-label ${statusClass}`}>{statusClass}</span></td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/public/chat.js
+++ b/frontend/public/chat.js
@@ -1,0 +1,41 @@
+function Chat() {
+  const [messages, setMessages] = React.useState([]);
+  const [input, setInput] = React.useState("");
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage = { sender: "user", text: input };
+    setMessages(prev => [...prev, userMessage]);
+    try {
+      const res = await fetch("http://localhost:8000/ask", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: input })
+      });
+      const data = await res.json();
+      const botMessage = { sender: "bot", text: data.response };
+      setMessages(prev => [...prev, botMessage]);
+    } catch (err) {
+      const botMessage = { sender: "bot", text: "Error: " + err.message };
+      setMessages(prev => [...prev, botMessage]);
+    }
+    setInput("");
+  };
+
+  return (
+    <div>
+      <div className="chat-container">
+        {messages.map((m, idx) => (
+          <div key={idx}><strong>{m.sender}:</strong> {m.text}</div>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        onKeyDown={e => { if (e.key === 'Enter') sendMessage(); }}
+      />
+      <button onClick={sendMessage}>Send</button>
+    </div>
+  );
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Doctor Appointment Assistant</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="chat.js"></script>
+  <script type="text/babel" src="calendar.js"></script>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -1,0 +1,26 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 20px;
+}
+.chat-container {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  height: 300px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+.status-label {
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #000;
+  display: inline-block;
+}
+.available {
+  background-color: #c8e6c9;
+}
+.busy {
+  background-color: #ffcdd2;
+}
+.holiday {
+  background-color: #fff9c4;
+}


### PR DESCRIPTION
## Summary
- add simple React frontend to chat with AI and view appointment calendar
- expose `/appointments` API in the backend
- secure OpenAI key via env variable

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_687fb6b880508330a5fca15ae6885aa0